### PR TITLE
Add hardware.inc as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "include/hardware.inc"]
+	path = include/hardware.inc
+	url = https://github.com/gbdev/hardware.inc

--- a/include/struct/vram/entsys_test.inc
+++ b/include/struct/vram/entsys_test.inc
@@ -1,7 +1,7 @@
     IF !DEF(STRUCT_VRAM_ENTSYS_TEST_INC)
     DEF STRUCT_VRAM_ENTSYS_TEST_INC EQU 1
 
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/tilemap.inc"
 
 ;Block 0 (sprites only)

--- a/source/core/input.asm
+++ b/source/core/input.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 
 SECTION "INPUT", ROM0
 ; Gets the current buttons pressed.

--- a/source/core/rectangle.asm
+++ b/source/core/rectangle.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "struct/vqueue.inc"
 
 ; What tile to start drawing from

--- a/source/core/setup.asm
+++ b/source/core/setup.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/color.inc"
 INCLUDE "macros/farcall.inc"
 

--- a/source/core/snippets.asm
+++ b/source/core/snippets.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 
 SECTION "SNIPPETS", ROM0
 

--- a/source/core/sprites.asm
+++ b/source/core/sprites.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "struct/oam_mirror.inc"
 
 SECTION "SPRITES", ROM0

--- a/source/core/variables.asm
+++ b/source/core/variables.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "entsys.inc"
 INCLUDE "macros/color.inc"
 INCLUDE "struct/oam_mirror.inc"

--- a/source/entities/platform_test.asm
+++ b/source/entities/platform_test.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "entsys.inc"
 INCLUDE "struct/vqueue.inc"
 

--- a/source/entitysystem/entsys.asm
+++ b/source/entitysystem/entsys.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "entsys.inc"
 
 SECTION "ENTSYS", ROM0

--- a/source/gameloops/error.asm
+++ b/source/gameloops/error.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/color.inc"
 
 SECTION "ERROR SCREEN VECTOR", ROM0[$0038]

--- a/source/gameloops/intro.asm
+++ b/source/gameloops/intro.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/color.inc"
 INCLUDE "macros/memcpy.inc"
 

--- a/source/gameloops/loading.asm
+++ b/source/gameloops/loading.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/color.inc"
 
 SECTION "GAMELOOP LOADING", ROM0

--- a/source/gameloops/testing.asm
+++ b/source/gameloops/testing.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/memcpy.inc"
 INCLUDE "macros/numtohex.inc"
 INCLUDE "struct/vqueue.inc"

--- a/source/main.asm
+++ b/source/main.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 
 
 SECTION "NOTICE", ROM0[$0000]

--- a/source/painter.asm
+++ b/source/painter.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "macros/memcpy.inc"
 INCLUDE "struct/vqueue.inc"
 

--- a/source/vqueue.asm
+++ b/source/vqueue.asm
@@ -1,4 +1,4 @@
-INCLUDE "hardware.inc"
+INCLUDE "hardware.inc/hardware.inc"
 INCLUDE "struct/vqueue.inc"
 INCLUDE "macros/memcpy.inc"
 


### PR DESCRIPTION
Instead of copying the file directly, it is now included as a submodule.
This has a few side effects:
* Include path for hardware.inc has changed
* Now using latest version of hardware.inc